### PR TITLE
Fix for Eksisozluk links

### DIFF
--- a/modules/eksisozluk.js
+++ b/modules/eksisozluk.js
@@ -31,7 +31,7 @@ var eksisozlukModule = {
                         if (response2.statusCode == 200) {
                             var bodyWithBreaksAndTrimmedLinks = body2.replace(/\<br[^\>]*\>/gi, '\n')
                                 .replace(/<a([^>]* )href="([^"]+)">([^"]+)<\/a>/gi, '$2'); // hack
-                            var $ = cheerio.load(bodyWithBreaks);
+                            var $ = cheerio.load(bodyWithBreaksAndTrimmedLinks);
 
                             var header = $('#title');
 

--- a/modules/eksisozluk.js
+++ b/modules/eksisozluk.js
@@ -29,7 +29,8 @@ var eksisozlukModule = {
                         }
 
                         if (response2.statusCode == 200) {
-                            var bodyWithBreaks = body2.replace(/\<br[^\>]*\>/gi, '\n'); // hack
+                            var bodyWithBreaksAndTrimmedLinks = body2.replace(/\<br[^\>]*\>/gi, '\n')
+                                .replace(/<a([^>]* )href="([^"]+)">([^"]+)<\/a>/gi, '$2'); // hack
                             var $ = cheerio.load(bodyWithBreaks);
 
                             var header = $('#title');


### PR DESCRIPTION
Eksisozluk outputs all characters visible by eye lowercased. Therefore, while parsing the output, the links which are case sensitive (e.g Youtube) are not provided correctly.

I simply added another regular expression to parse and extract links from HTML:

Regex description and sample matches: https://regex101.com/r/yT4pZ3/2

Working example in JSFiddle: https://jsfiddle.net/j8tbmwrz/1/

Thank you!
